### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*, 12.*]
+        laravel: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*, 12.*, 13.*]
         dependency-version: [prefer-stable]
         include:
           - testbench: 10.*
             laravel: 12.*
+          - testbench: 11.*
+            laravel: 13.*
           - testbench: 9.*
             laravel: 11.*
           - testbench: 8.*
@@ -74,6 +76,16 @@ jobs:
             laravel: 6.*
           - php: 8.5
             laravel: 7.*
+          - php: 7.3
+            laravel: 13.*
+          - php: 7.4
+            laravel: 13.*
+          - php: 8.0
+            laravel: 13.*
+          - php: 8.1
+            laravel: 13.*
+          - php: 8.2
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/database": "~6.0,!=6.9.0|~7.0|~8.0|~9.0|~10.0|~11.0|~12.0",
-        "illuminate/mail": "~6.0|~7.0|~8.0|~9.0|~10.0|~11.0|~12.0"
+        "illuminate/database": "~6.0,!=6.9.0|~7.0|~8.0|~9.0|~10.0|~11.0|~12.0|~13.0",
+        "illuminate/mail": "~6.0|~7.0|~8.0|~9.0|~10.0|~11.0|~12.0|~13.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",
-        "orchestra/testbench": "~4.0|~5.0|~6.0|~7.0|~8.0|~9.0|~10.0",
-        "phpunit/phpunit": "^9.3|^10.0|^11.0"
+        "orchestra/testbench": "~4.0|~5.0|~6.0|~7.0|~8.0|~9.0|~10.0|~11.0",
+        "phpunit/phpunit": "^9.3|^10.0|^11.0|^12.5"
     },
     "prefer-stable": true,
     "minimum-stability": "dev",

--- a/tests/Unit/TransaciontalMailableTest.php
+++ b/tests/Unit/TransaciontalMailableTest.php
@@ -10,7 +10,6 @@ use Illuminate\Mail\Transport\ArrayTransport;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
-
 class TransaciontalMailableTest extends TestCase
 {
     protected function mailTransport(): ArrayTransport
@@ -27,8 +26,7 @@ class TransaciontalMailableTest extends TestCase
         return $mailer->getSymfonyTransport();
     }
 
-    /** @test */
-    public function it_sends_mail_after_db_commit()
+    public function test_it_sends_mail_after_db_commit()
     {
         DB::beginTransaction();
         Mail::to('user@example.com')->send(new DummyTransactionalMail());
@@ -38,8 +36,7 @@ class TransaciontalMailableTest extends TestCase
         $this->assertCount(1, $this->mailTransport()->messages());
     }
 
-    /** @test */
-    public function it_queues_mail_after_db_commit()
+    public function test_it_queues_mail_after_db_commit()
     {
         Queue::fake();
 
@@ -51,8 +48,7 @@ class TransaciontalMailableTest extends TestCase
         Queue::assertPushed(SendQueuedMailable::class);
     }
 
-    /** @test */
-    public function it_sends_mail_later_after_db_commit()
+    public function test_it_sends_mail_later_after_db_commit()
     {
         Queue::fake();
 
@@ -64,8 +60,7 @@ class TransaciontalMailableTest extends TestCase
         Queue::assertPushed(SendQueuedMailable::class);
     }
 
-    /** @test */
-    public function it_does_not_sends_mail_after_db_rollback()
+    public function test_it_does_not_sends_mail_after_db_rollback()
     {
         DB::beginTransaction();
         Mail::to('user@example.com')->send(new DummyTransactionalMail());
@@ -75,8 +70,7 @@ class TransaciontalMailableTest extends TestCase
         $this->assertCount(0, $this->mailTransport()->messages());
     }
 
-    /** @test */
-    public function it_does_not_queue_mail_after_db_rollback()
+    public function test_it_does_not_queue_mail_after_db_rollback()
     {
         Queue::fake();
 
@@ -88,8 +82,7 @@ class TransaciontalMailableTest extends TestCase
         Queue::assertNothingPushed();
     }
 
-    /** @test */
-    public function it_does_not_send_mail_later_after_db_rollback()
+    public function test_it_does_not_send_mail_later_after_db_rollback()
     {
         Queue::fake();
 
@@ -101,8 +94,7 @@ class TransaciontalMailableTest extends TestCase
         Queue::assertNothingPushed();
     }
 
-    /** @test */
-    public function it_sends_mail_when_outer_transaction_is_committed()
+    public function test_it_sends_mail_when_outer_transaction_is_committed()
     {
         DB::beginTransaction();
         DB::beginTransaction();
@@ -129,8 +121,7 @@ class TransaciontalMailableTest extends TestCase
         $this->assertCount(1, $this->mailTransport()->messages());
     }
 
-    /** @test */
-    public function it_directly_sends_mail_when_not_in_transaction()
+    public function test_it_directly_sends_mail_when_not_in_transaction()
     {
         Mail::to('user@example.com')->send(new DummyTransactionalMail());
 


### PR DESCRIPTION
## Summary
- Add Laravel 13 support to `illuminate/database` and `illuminate/mail` constraints
- Add `orchestra/testbench` 11.x and `phpunit/phpunit` 12.5 support
- Add Laravel 13 to CI matrix with appropriate PHP version exclusions (requires PHP 8.3+)
- Replace `/** @test */` annotations with `test_` method prefixes for PHPUnit 12 compatibility